### PR TITLE
Add SDLC repo-allow-list permissions for

### DIFF
--- a/.gruntwork/config.yml
+++ b/.gruntwork/config.yml
@@ -1,2 +1,3 @@
 repo-allow-list:
   - arsci-org-test/test-from-action
+  - arsci-org-test/


### PR DESCRIPTION
This pull request updates the `config.yml` `repo-allow-list` permissions file with the newly created SDLC `infrastructure-live` repository, which was created in https://github.com.